### PR TITLE
init to accept --key path/to/service-account.json

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"fmt"
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/appscode/go/io"
 	pb "github.com/dinesh/datacol/api/controller"
@@ -9,7 +11,6 @@ import (
 	"github.com/dinesh/datacol/cmd/stdcli"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"os"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 func init() {
 	root := models.ConfigPath
 	if err := io.EnsureDirectory(root); err != nil {
-		stdcli.Error(err)
+		stdcli.ExitOnError(err)
 	}
 }
 

--- a/cloud/google/cloudsql.go
+++ b/cloud/google/cloudsql.go
@@ -2,14 +2,14 @@ package google
 
 import (
 	"fmt"
+	"strings"
+
 	"k8s.io/client-go/kubernetes"
 	kerrors "k8s.io/client-go/pkg/api/errors"
 	kapi "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	sql "google.golang.org/api/sqladmin/v1beta4"
 )
 
 var (
@@ -18,42 +18,6 @@ var (
 	cloudsqlImage         = "gcr.io/cloudsql-docker/gce-proxy:1.09"
 	sqlCredVolName        = "cloudsql-instance-credentials"
 )
-
-func (g *GCPCloud) createSqlUser(user, password, instance string) error {
-	service := g.sqlAdmin()
-	log.Debugf("\ncreating user with %s:%s on database instance %s", user, password, instance)
-
-	op, err := service.Users.Insert(g.Project, instance, &sql.User{
-		Name:     user,
-		Password: password,
-	}).Do()
-
-	if err != nil {
-		return err
-	}
-
-	if err = waitForSqlOp(service, op, g.Project); err != nil {
-		return fmt.Errorf("Error, failure waiting %s:[%s] err:%v", op.OperationType, op.Name, err)
-	}
-
-	return nil
-}
-
-func (g *GCPCloud) getSqlInstance(name string) (*sql.DatabaseInstance, error) {
-	return g.sqlAdmin().Instances.Get(g.Project, name).Do()
-}
-
-func (g *GCPCloud) createSqlDatabase(name, instance string) error {
-	if _, err := g.sqlAdmin().Databases.Insert(g.Project, instance, &sql.Database{
-		Name:     name,
-		Project:  g.Project,
-		Instance: instance,
-	}).Do(); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 func tearCloudProxy(c *kubernetes.Clientset, ns, name, process string) error {
 	secretName := fmt.Sprintf("%s-%s", name, sqlSecretName)

--- a/cloud/google/resources.go
+++ b/cloud/google/resources.go
@@ -267,8 +267,11 @@ func (g *GCPCloud) resourceFromDeployment(dp *dm.Deployment, manifest *dm.Manife
 		rs.Status = dp.Operation.Status
 		rs.StatusReason = dp.Operation.StatusMessage
 
-		if rs.StatusReason == "" && dp.Operation.Error != nil {
-			rs.StatusReason = dp.Operation.HttpErrorMessage
+		if dp.Operation.Error != nil {
+			rs.Status = "FAILED"
+			if errText, err := dp.Operation.Error.MarshalJSON(); err == nil {
+				rs.StatusReason = string(errText)
+			}
 		}
 	}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -58,9 +58,7 @@ func cmdBuildList(c *cli.Context) error {
 	defer close()
 
 	builds, err := api.GetBuilds(name)
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	fmt.Println(toJson(builds))
 	return nil
@@ -68,21 +66,18 @@ func cmdBuildList(c *cli.Context) error {
 
 func cmdBuildDelete(c *cli.Context) error {
 	_, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
+
 	api, close := getApiClient(c)
 	defer close()
 
 	if c.Args().Len() == 0 {
-		return fmt.Errorf("Please provide id of the build")
+		stdcli.ExitOnError(fmt.Errorf("Please provide id of the build"))
 	}
 
 	bid := c.Args().First()
 
-	if err = api.DeleteBuild(name, bid); err != nil {
-		return err
-	}
+	stdcli.ExitOnError(api.DeleteBuild(name, bid))
 
 	fmt.Println("DONE")
 	return nil
@@ -93,9 +88,7 @@ func cmdBuild(c *cli.Context) error {
 	defer close()
 
 	dir, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	app, err := api.GetApp(name)
 	if err != nil {
@@ -110,6 +103,7 @@ func cmdBuild(c *cli.Context) error {
 		_, err = executeBuildGitSource(api, app, ref)
 	}
 
+	stdcli.ExitOnError(err)
 	return err
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,9 +48,7 @@ func init() {
 
 func cmdDeploy(c *cli.Context) error {
 	dir, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	client, close := getApiClient(c)
 	defer close()
@@ -65,17 +63,15 @@ func cmdDeploy(c *cli.Context) error {
 	buildId := c.String("build")
 
 	if len(buildId) == 0 {
-		if build, err = executeBuildDir(client, app, dir); err != nil {
-			return err
-		}
+		build, err = executeBuildDir(client, app, dir)
+		stdcli.ExitOnError(err)
 	} else {
 		b, err := client.GetBuild(name, buildId)
-		if err != nil {
-			return err
-		}
+		stdcli.ExitOnError(err)
 
 		if b == nil {
-			return fmt.Errorf("No build found by id: %s.", buildId)
+			err = fmt.Errorf("No build found by id: %s.", buildId)
+			stdcli.ExitOnError(err)
 		}
 
 		build = b
@@ -83,13 +79,13 @@ func cmdDeploy(c *cli.Context) error {
 
 	fmt.Printf("Deploying build %s\n", build.Id)
 
-	if _, err = client.ReleaseBuild(build, c.Bool("wait")); err != nil {
-		return err
-	}
+	_, err = client.ReleaseBuild(build, c.Bool("wait"))
+	stdcli.ExitOnError(err)
 
 	app, err = client.GetApp(name)
 	if err != nil {
-		return fmt.Errorf("fetching app %s err: %v", name, err)
+		err = fmt.Errorf("fetching app %s err: %v", name, err)
+		stdcli.ExitOnError(err)
 	}
 
 	if len(app.Endpoint) > 0 {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	pb "github.com/dinesh/datacol/api/models"
 	"github.com/dinesh/datacol/cmd/stdcli"
 	"gopkg.in/urfave/cli.v2"
@@ -29,21 +30,18 @@ func init() {
 
 func cmdConfigList(c *cli.Context) error {
 	_, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	ct, close := getApiClient(c)
 	defer close()
 
 	if _, err = ct.GetApp(name); err != nil {
-		return fmt.Errorf("failed to fetch app: %v", err)
+		err = fmt.Errorf("failed to fetch app: %v", err)
+		stdcli.ExitOnError(err)
 	}
 
 	env, err := ct.GetEnvironment(name)
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	data := ""
 	for key, value := range env {
@@ -56,9 +54,7 @@ func cmdConfigList(c *cli.Context) error {
 
 func cmdConfigSet(c *cli.Context) error {
 	_, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	ct, close := getApiClient(c)
 	defer close()
@@ -83,17 +79,13 @@ func cmdConfigSet(c *cli.Context) error {
 
 func cmdConfigUnset(c *cli.Context) error {
 	_, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	client, close := getApiClient(c)
 	defer close()
 
 	env, err := client.GetEnvironment(name)
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	keyvar := c.Args().First()
 	data := ""

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -14,19 +14,12 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	term "github.com/appscode/go-term"
 	"github.com/dinesh/datacol/cmd/stdcli"
 	"gopkg.in/yaml.v2"
 )
 
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
-}
-
-func exitOnError(err error) {
-	if err != nil {
-		term.Fatalln(err)
-	}
 }
 
 func withIntSuffix(seed string) string {

--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"golang.org/x/net/context"
 	"os"
+
+	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 	pbs "github.com/dinesh/datacol/api/controller"
@@ -26,10 +27,8 @@ func cmdKubectl(c *cli.Context) error {
 
 	args := c.Args().Slice()
 	ret, err := client.ProviderServiceClient.Kubectl(context.TODO(), &pbs.KubectlReq{Args: args})
+	stdcli.ExitOnError(err)
 
-	if err != nil {
-		return err
-	}
 	onApiExec(ret, args)
 	return nil
 }
@@ -39,7 +38,7 @@ func onApiExec(ret *pbs.CmdResponse, args []string) {
 	if len(ret.Err) > 0 {
 		log.Warn(ret.Err)
 		log.Warn(ret.StdErr)
-		fmt.Printf("failed to execute %v", args)
+		fmt.Printf("failed to execute %v\n", args)
 	} else {
 		if exitcode == 0 {
 			fmt.Printf(ret.StdOut)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,14 +3,15 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	pbs "github.com/dinesh/datacol/api/controller"
 	"github.com/dinesh/datacol/client"
 	"github.com/dinesh/datacol/cmd/stdcli"
 	"golang.org/x/net/context"
 	"gopkg.in/urfave/cli.v2"
-	"os"
-	"strings"
 )
 
 func init() {
@@ -34,9 +35,7 @@ func cmdLogin(c *cli.Context) error {
 	fmt.Print("Enter your password: ")
 
 	p, err := r.ReadString('\n')
-	if err != nil {
-		log.Fatal(err)
-	}
+	stdcli.ExitOnError(err)
 
 	passwd := strings.TrimSpace(p)
 	host := c.String("ip")
@@ -46,12 +45,12 @@ func cmdLogin(c *cli.Context) error {
 
 	log.Debugf("Trying to login with [%s]", passwd)
 	ret, err := api.Auth(context.TODO(), &pbs.AuthRequest{Password: passwd})
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	log.Debugf("response: %+v", toJson(ret))
+
 	if err = updateSetting(ret, host, passwd); err != nil {
+		stdcli.ExitOnError(err)
 		return err
 	}
 
@@ -61,6 +60,7 @@ func cmdLogin(c *cli.Context) error {
 
 func updateSetting(ret *pbs.AuthResponse, host, passwd string) error {
 	if err := createStackDir(ret.Name); err != nil {
+		stdcli.ExitOnError(err)
 		return err
 	}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/dinesh/datacol/cmd/stdcli"
-	"gopkg.in/urfave/cli.v2"
 	"os"
 	"time"
+
+	"github.com/dinesh/datacol/cmd/stdcli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 func init() {
@@ -29,20 +30,20 @@ func init() {
 
 func cmdAppLogStream(c *cli.Context) error {
 	_, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	client, close := getApiClient(c)
 	defer close()
 
-	if _, err := client.GetApp(name); err != nil {
-		return err
-	}
+	_, err = client.GetApp(name)
+	stdcli.ExitOnError(err)
 
 	if c.NArg() > 0 {
 		name = c.Args().Get(0)
 	}
 
-	return client.StreamAppLogs(name, c.Bool("follow"), c.Duration("since"), os.Stdout)
+	err = client.StreamAppLogs(name, c.Bool("follow"), c.Duration("since"), os.Stdout)
+	stdcli.ExitOnError(err)
+
+	return err
 }

--- a/cmd/provider/gcp/gcp.go
+++ b/cmd/provider/gcp/gcp.go
@@ -34,10 +34,12 @@ const (
 type InitOptions struct {
 	Name, Project, ClusterName, MachineType, Zone, Bucket string
 	ApiKey, Version, Region, ArtifactBucket               string
-	SAEmail, ClusterVersion                               string
-	ProjectNumber                                         int64
-	DiskSize, NumNodes, ControllerPort                    int
-	ClusterNotExists, Preemptible                         bool
+
+	// SA stands for Service Account
+	SAKeyPath, SAEmail, ClusterVersion string
+
+	DiskSize, NumNodes, ControllerPort int
+	ClusterNotExists, Preemptible      bool
 }
 
 type initResponse struct {
@@ -328,7 +330,7 @@ resources:
 - name: {{ env['name'] }}
   type: storage.v1.bucket
   properties:
-    projectNumber: {{ properties['projectNumber'] }}
+    name: {{ env['name'] }}
 `
 
 const kubeClusterYAML = `
@@ -349,7 +351,7 @@ resources:
       nodeConfig:
         preemptible: {{ properties['preemptible'] }}
         machineType: {{ properties['machineType'] }}
-        imageType: CONTAINER_VM
+        imageType: COS
         diskSizeGb: {{ properties['diskSize'] }}
         oauthScopes:
           - https://www.googleapis.com/auth/compute
@@ -367,7 +369,6 @@ resources:
 - type: registry.jinja
   name: {{ .Bucket }}
   properties:
-    projectNumber: {{ .ProjectNumber }}
     zone: {{ .Zone }}
 
 - type: compute.jinja
@@ -436,6 +437,7 @@ resources:
         - https://www.googleapis.com/auth/devstorage.read_write
         - https://www.googleapis.com/auth/logging.write
         - https://www.googleapis.com/auth/monitoring
+        - https://www.googleapis.com/auth/sqlservice.admin
     tags:
       items:
         - datacol

--- a/cmd/provider/gcp/oauth.go
+++ b/cmd/provider/gcp/oauth.go
@@ -200,15 +200,20 @@ func setIamPolicy(rackName, accessToken string) (*iam.Service, error) {
 
 	fmt.Println("\nPlease choose a project to continue.")
 
-	i, _ := term.List(projects)
-	projectId = presp.Projects[i].ProjectId
-	pNumber = presp.Projects[i].ProjectNumber
+	_, selectedName := term.List(projects)
+
+	for _, p := range presp.Projects {
+		if selectedName == p.Name {
+			projectId = p.ProjectId
+			break
+		}
+	}
 
 	if len(projectId) == 0 {
 		return nil, fmt.Errorf("Please select atleast an option.")
 	}
 
-	log.Debugf("Selected ProjectId: %s", projectId)
+	log.Debugf("Selected ProjectId: %s Name: %s", projectId, selectedName)
 
 	iamClient, err := iam.New(client)
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,22 +15,18 @@ func init() {
 
 func cmdAppRun(c *cli.Context) error {
 	_, name, err := getDirApp(".")
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
 
 	client, close := getApiClient(c)
 	defer close()
 
-	if _, err := client.GetApp(name); err != nil {
-		return err
-	}
+	_, err = client.GetApp(name)
+	stdcli.ExitOnError(err)
 
 	args := c.Args().Slice()
 	ret, err := client.RunProcess(name, args)
-	if err != nil {
-		return err
-	}
+	stdcli.ExitOnError(err)
+
 	onApiExec(ret, args)
 
 	return nil

--- a/cmd/stdcli/cli.go
+++ b/cmd/stdcli/cli.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	term "github.com/appscode/go-term"
 	pb "github.com/dinesh/datacol/api/models"
 	rollbarAPI "github.com/stvp/rollbar"
 	"gopkg.in/urfave/cli.v2"
@@ -53,7 +54,7 @@ func GetAppStack() string {
 	}
 
 	if stack == "" {
-		Error(Stack404)
+		ExitOnError(Stack404)
 	}
 	return stack
 }
@@ -128,15 +129,16 @@ func CheckFlagsPresence(c *cli.Context, flags ...string) {
 	for _, name := range flags {
 		value := c.String(name)
 		if value == "" {
-			Error(fmt.Errorf("Missing required param %v", name))
+			term.Errorln(fmt.Errorf("Missing required param --%v", name))
+			cli.ShowCommandHelp(c, c.Command.Name)
+			os.Exit(1)
 		}
 	}
 }
 
-func Error(err error) {
+func ExitOnError(err error) {
 	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
+		term.Fatalln(err)
 	}
 }
 
@@ -149,7 +151,7 @@ func HandlePanicErr(err error) {
 func EnsureOnlyFlags(c *cli.Context, args []string) {
 	for _, a := range args {
 		if !strings.HasPrefix(a, "--") {
-			Error(fmt.Errorf("got unexpected argument '%s'; please provide parameters in --flag or --flag=value format", a))
+			ExitOnError(fmt.Errorf("got unexpected argument '%s'; please provide parameters in --flag or --flag=value format", a))
 			Usage(c)
 		}
 	}


### PR DESCRIPTION
This PR have following updates -

- [x] Accept service-account key for GCP based stacks
- [x] Refactoring to used stdcli.ExitOnError
- [x] Default cluster version for GCP `1.7.6-gke.1`
- [x] Better support for failed events for GCP based stacks
