### PR TITLE
Adding proctype as prefix for logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -43,6 +43,12 @@
   version = "v1.10.9"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/bjaglin/multiplexio"
+  packages = ["."]
+  revision = "7477705f395a7cc682ae2453b04377e9f4984779"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
@@ -556,6 +562,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "57e024767ea1480e23cdf5365cfc58ebbff83e0dc665413118631fb37a45e8af"
+  inputs-digest = "16cdf31c9a667773efc73382a9691e7c57e07363dd300466daa2946418ecc04a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/bjaglin/multiplexio/.gitignore
+++ b/vendor/github.com/bjaglin/multiplexio/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/bjaglin/multiplexio/.travis.yml
+++ b/vendor/github.com/bjaglin/multiplexio/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+  - 1.3

--- a/vendor/github.com/bjaglin/multiplexio/LICENSE
+++ b/vendor/github.com/bjaglin/multiplexio/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/bjaglin/multiplexio/README.md
+++ b/vendor/github.com/bjaglin/multiplexio/README.md
@@ -1,0 +1,23 @@
+multiplexio
+===========
+
+Go library providing I/O wrappers for aggregating streams.
+
+[![Build Status](https://travis-ci.org/bjaglin/multiplexio.svg?branch=master)](https://travis-ci.org/bjaglin/multiplexio)
+[![GoDoc](https://godoc.org/github.com/bjaglin/multiplexio?status.svg)](https://godoc.org/github.com/bjaglin/multiplexio)
+
+## Usage
+
+See [godoc](http://godoc.org/github.com/bjaglin/multiplexio). For usage examples, the best is currently to check the project's [tests](https://github.com/bjaglin/multiplexio/blob/master/multiplexio_test.go).
+
+## Versioning policy
+
+The API defined by this package is still considered unstable. However, until a fully backward-compatible v1 branch is created, the only changes in the existing API will be new configuration or customization fields. Therefore, as long as you initialize all structs declared in this project using explicit names, you will will not be affected by them.
+
+For example, instead of:
+
+    Source{reader1}
+
+Prefer:
+
+    Source{Reader: reader1}

--- a/vendor/github.com/bjaglin/multiplexio/multiplexio.go
+++ b/vendor/github.com/bjaglin/multiplexio/multiplexio.go
@@ -1,0 +1,205 @@
+// Package multiplexio exposes structs implementing and wrapping
+// canonical I/O interfaces to tokenize, process and aggregate
+// them with custom functions.
+package multiplexio
+
+import (
+	"bufio"
+	"io"
+	"sort"
+	"time"
+)
+
+var (
+	firstTimeout = time.Second      // how long do we wait for an initial token from each reader?
+	timeout      = time.Millisecond // how long do we wait for tokens after at least one reader produced one?
+)
+
+// NewReader returns an io.ReadCloser aggregating, according to a given
+// ordering, tokens extracted concurrently from a set of io.Reader
+// wrapped in a set of Source. Tokens of a given io.Reader go through
+// the Write function passed together in the Source struct, or
+// WriteNewLine if it is not set.
+//
+// If the corresponding functions are not passed in Options,
+// bufio.ScanLines is used for scanning and extracting tokens from the
+// wrapped io.Reader objects, and ByStringLess is invoked for defining
+// the order of these onto the aggregated stream.
+func NewReader(options Options, sources ...Source) io.ReadCloser {
+	// configuration
+	var (
+		split = bufio.ScanLines // tokenizing function
+		less  = ByStringLess    // sorting function defining which token gets out first
+	)
+	if options.Split != nil {
+		split = options.Split
+	}
+	if options.Less != nil {
+		less = options.Less
+	}
+
+	// plumbing tools
+	var (
+		pipeReader, pipeWriter = io.Pipe()
+		ch                     = make(chan sourceToken)
+	)
+
+	// goroutines scanning & extracting tokens to feed them into
+	// the main goroutine via the channel
+	source2chan := func(source Source) {
+		var (
+			// a chan used as a semaphore to throttle the scanning loop
+			scanSemaphore = make(chan struct{})
+
+			// the object extracting tokens
+			scanner = bufio.NewScanner(source.Reader)
+
+			// the function that will format and forward the tokens
+			write = source.Write
+		)
+		if write == nil {
+			write = WriteNewLine
+		}
+		scanner.Split(split)
+		for scanner.Scan() {
+			ch <- sourceToken{
+				source:        &source,
+				bytes:         scanner.Bytes(),
+				scanSemaphore: scanSemaphore,
+				write:         write,
+			}
+			// block until we are asked to consume more
+			<-scanSemaphore
+		}
+		// signal that there is nothing else coming from that routine
+		ch <- sourceToken{source: &source}
+		// TODO: better error handling: check scanner.Err()
+	}
+	for _, source := range sources {
+		go source2chan(source)
+	}
+
+	// goroutine feeding into PipeWriter as tokens arrive
+	go func() {
+		var (
+			// current number of sources that have not EOFed and are actively scanning
+			scanning = len(sources)
+
+			// extracted tokens, candidate for sorting/forwarding
+			sourceTokens = make([]sourceToken, 0, len(sources))
+
+			// the max duration we are willing to wait for tokens
+			blockMax = firstTimeout
+
+			// the one and only source after which we can move on if we receive a token from
+			criticalSource *Source
+		)
+		for scanning != 0 {
+			var (
+				stopWaiting = false
+				tokenTimer  = time.After(blockMax)
+			)
+			for scanning != 0 && !stopWaiting {
+				timer := tokenTimer
+				if len(sourceTokens) == 0 {
+					// nothing is extracted yet so we need at least a token to do
+					// anything, so no need for any timeout that would result in
+					// busy-polling
+					timer = nil
+				}
+				select {
+				case sourceToken, ok := <-ch:
+					if ok {
+						if sourceToken.scanSemaphore != nil {
+							// candidate for being forwarded, put it in the list to be sorted
+							sourceTokens = append(sourceTokens, sourceToken)
+						}
+						if criticalSource == sourceToken.source {
+							// no need to wait for another source, the other ones are either
+							// not scanning or were already given enough time
+							stopWaiting = true
+						}
+					}
+					scanning--
+				case <-timer:
+					stopWaiting = true
+				}
+			}
+			criticalSource = nil
+			if len(sourceTokens) > 0 {
+				// sort to get the token we want at the tail
+				sort.Sort(byTokenSort{less, &sourceTokens})
+				// extract the tail from the sorted list
+				sourceToken := extractTail(&sourceTokens)
+				// dump the bytes, blocking until they are consumed
+				if _, err := sourceToken.write(pipeWriter, sourceToken.bytes); err != nil {
+					// TODO: gracefully cleanup reader2chan goroutines? close semaphores?
+					close(ch)
+					break
+				}
+				// signal that we want more data from the source we got that token from
+				sourceToken.scanSemaphore <- struct{}{}
+				// which makes it the one and only critical source we need data from in the next select
+				criticalSource = sourceToken.source
+				scanning++
+			}
+			blockMax = timeout
+		}
+		pipeWriter.Close()
+	}()
+
+	return pipeReader
+}
+
+// Source combines an io.Reader from which tokens will be extracted with
+// the Write function that will format them and dump them into the aggregated
+// stream.
+type Source struct {
+	Reader io.Reader                                             // incoming stream
+	Write  func(dest io.Writer, token []byte) (n int, err error) // function used for formatting and dumping extracted tokens
+}
+
+// Implementation of Source.Write adding a line break after each token.
+func WriteNewLine(dest io.Writer, token []byte) (n int, err error) {
+	return dest.Write(append(token, byte('\n')))
+}
+
+// Options are the options for creating a new Reader.
+type Options struct {
+	Split bufio.SplitFunc        // function used for scanning and extracting tokens
+	Less  func(i, j []byte) bool // function used for ordering extracted tokens, with sort.Interface.Less semantics
+}
+
+// Implementation of Options.Less using the alphabetical string ordering.
+func ByStringLess(i, j []byte) bool {
+	return string(i) < string(j)
+}
+
+type sourceToken struct {
+	source        *Source
+	bytes         []byte
+	scanSemaphore chan struct{}
+	write         func(dest io.Writer, token []byte) (n int, err error)
+}
+
+type byTokenSort struct {
+	less   func(i, j []byte) bool
+	tokens *[]sourceToken
+}
+
+func (b byTokenSort) Len() int {
+	return len(*b.tokens)
+}
+func (b byTokenSort) Swap(i, j int) {
+	(*b.tokens)[i], (*b.tokens)[j] = (*b.tokens)[j], (*b.tokens)[i]
+}
+func (b byTokenSort) Less(i, j int) bool {
+	return !b.less((*b.tokens)[i].bytes, (*b.tokens)[j].bytes)
+}
+
+func extractTail(sourceTokens *[]sourceToken) sourceToken {
+	l := len(*sourceTokens)
+	tail := (*sourceTokens)[l-1]
+	*sourceTokens = (*sourceTokens)[0 : l-1]
+	return tail
+}

--- a/vendor/github.com/bjaglin/multiplexio/multiplexio_test.go
+++ b/vendor/github.com/bjaglin/multiplexio/multiplexio_test.go
@@ -1,0 +1,609 @@
+package multiplexio
+
+import (
+	"bufio"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func init() {
+	firstTimeout = 100 * time.Millisecond
+	timeout = 10 * time.Millisecond
+}
+
+const (
+	line1          = "1 foo\n"
+	line2          = "2 barbar\n"
+	line3          = "3 quxquxqux\n"
+	line4          = "4 bazbazbazbaz\n"
+	unfinishedLine = "5 thisisnotacompletetoken"
+)
+
+func concatenatedStringsAsBytes(strings ...string) []byte {
+	buf := make([]byte, 0, 1024)
+	for _, s := range strings {
+		buf = append(buf, []byte(s)...)
+	}
+
+	return buf
+}
+
+func readOneByteAtTheTime(src io.Reader, written *int) []byte {
+	buf := make([]byte, 1024)
+	for {
+		n, err := io.ReadAtLeast(src, buf[*written:], 1)
+		if err != nil {
+			break
+		}
+		*written = *written + n
+	}
+	return buf[:*written]
+}
+
+// Ensure data is read from sources only when necessary
+func TestLazyWrappedReaderFetching(t *testing.T) {
+	var (
+		pipeReader, pipeWriter = io.Pipe()
+		reader                 = NewReader(
+			Options{},
+			Source{Reader: pipeReader},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter, line1)
+		io.WriteString(pipeWriter, line1)
+		io.WriteString(pipeWriter, line1)
+		pipeWriter.Close()
+	}()
+	// ask for enough bytes to get the first token
+	io.CopyN(ioutil.Discard, reader, int64(len(line1)))
+	go func() {
+		// asking for one byte should consume only one more token
+		io.CopyN(ioutil.Discard, reader, 1)
+	}()
+	// independently of our timeouts, give enough time to CopyN to block
+	time.Sleep(10 * time.Millisecond)
+	unconsumed, _ := io.Copy(ioutil.Discard, pipeReader)
+	// leaving one token that we had no reason to fetch
+	expected := int64(len(line1))
+	if unconsumed != expected {
+		t.Errorf("%v bytes unconsumed by the implementation, %v expected", unconsumed, expected)
+	}
+}
+
+// Verify that a single reader so slow that it triggers all timeouts
+// is forwarded correctly
+func TestForwardingSingleVerySlowReader(t *testing.T) {
+	var (
+		pipeReader, pipeWriter = io.Pipe()
+		reader                 = NewReader(
+			Options{},
+			Source{Reader: pipeReader},
+		)
+	)
+	go func() {
+		time.Sleep(2 * firstTimeout)
+		io.WriteString(pipeWriter, line1)
+		time.Sleep(2 * timeout)
+		io.WriteString(pipeWriter, line2)
+		time.Sleep(2 * timeout)
+		pipeWriter.Close()
+	}()
+	written, _ := io.Copy(ioutil.Discard, reader)
+	expected := int64(len(line1 + line2))
+	if written != expected {
+		t.Errorf("%v bytes copied, %v expected", written, expected)
+	}
+}
+
+// Verify that one reader which is slow but within the read timeouts doesn't
+// affect forwarding
+func TestForwardingOneSlowReader(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		pipeWriter1.Close()
+		time.Sleep(firstTimeout / 2)
+		io.WriteString(pipeWriter2, line2)
+		time.Sleep(timeout / 2)
+		io.WriteString(pipeWriter2, line3)
+		time.Sleep(timeout / 2)
+		pipeWriter2.Close()
+	}()
+	written, _ := io.Copy(ioutil.Discard, reader)
+	expected := int64(len(line1 + line2 + line3))
+	if written != expected {
+		t.Errorf("%v bytes copied, %v expected", written, expected)
+	}
+}
+
+// Verify that one reader which is so slow that it triggers the timeouts
+// doesn't affect forwarding
+func TestForwardingOneVerySlowReader(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		pipeWriter1.Close()
+		time.Sleep(2 * firstTimeout)
+		io.WriteString(pipeWriter2, line2)
+		time.Sleep(2 * timeout)
+		io.WriteString(pipeWriter2, line3)
+		time.Sleep(2 * timeout)
+		pipeWriter2.Close()
+	}()
+	written, _ := io.Copy(ioutil.Discard, reader)
+	expected := int64(len(line1 + line2 + line3))
+	if written != expected {
+		t.Errorf("%v bytes copied, %v expected", written, expected)
+	}
+}
+
+// Verify that data from a reader which is not closed is forwarded correctly
+// and that the aggregated reader blocks
+func TestForwardingSingleHangingReader(t *testing.T) {
+	var (
+		pipeReader, pipeWriter = io.Pipe()
+		reader                 = NewReader(
+			Options{},
+			Source{Reader: pipeReader},
+		)
+		written     int
+		doneReading bool
+	)
+	go func() {
+		io.WriteString(pipeWriter, line1)
+		io.WriteString(pipeWriter, unfinishedLine)
+	}()
+	go func() {
+		readOneByteAtTheTime(reader, &written)
+		doneReading = true
+	}()
+	time.Sleep(2 * timeout)
+	expected := len(line1)
+	if written != expected {
+		t.Errorf("%v bytes copied, %v expected", written, expected)
+	}
+	if doneReading {
+		t.Errorf("reader expected to block but was done reading")
+	}
+}
+
+// Verify that data from one reader which is not closed is forwarded correctly
+// and that the aggregated reader blocks
+func TestForwardingOneHangingReader(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		pipeReader3, _           = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+			Source{Reader: pipeReader3},
+		)
+		written     int
+		doneReading bool
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		pipeWriter1.Close()
+		io.WriteString(pipeWriter2, line2)
+		pipeWriter2.Close()
+	}()
+	go func() {
+		readOneByteAtTheTime(reader, &written)
+		doneReading = true
+	}()
+	time.Sleep(2 * firstTimeout)
+	expected := len(line1 + line2)
+	if written != expected {
+		t.Errorf("%v bytes copied, %v expected", written, expected)
+	}
+	if doneReading {
+		t.Errorf("reader expected to block but was done reading")
+	}
+}
+
+// Verify that a high volume, high frequency stream of tokens
+// that should be ordered last does not take precedence over
+// a low volume, low frequency stream of tokens that should
+// be ordered first
+func TestOrderingSequential(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+		expected = make([]byte, 0, 1024)
+	)
+	go func() {
+		// exercise the initial waiting by delaying token
+		// availability in the stream that should come first
+		time.Sleep(firstTimeout / 2)
+		for i := 0; i < 10; i++ {
+			io.WriteString(pipeWriter1, line1)
+			time.Sleep(timeout / 2)
+		}
+		pipeWriter1.Close()
+	}()
+	go func() {
+		for i := 0; i < 100; i++ {
+			io.WriteString(pipeWriter2, line2)
+		}
+		pipeWriter2.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	for i := 0; i < 10; i++ {
+		expected = append(expected, []byte(line1)...)
+	}
+	for i := 0; i < 100; i++ {
+		expected = append(expected, []byte(line2)...)
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Ensure tokens from a low frequency stream can be interlaced with the ones
+// from a high frequency stream
+func TestOrderingInterlaced(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		// exercise the initial waiting by delaying token
+		// availability in the stream that should come first
+		time.Sleep(firstTimeout / 2)
+		io.WriteString(pipeWriter1, line1)
+		time.Sleep(timeout / 2)
+		io.WriteString(pipeWriter1, line1)
+		time.Sleep(timeout / 2)
+		io.WriteString(pipeWriter1, line3)
+		pipeWriter1.Close()
+	}()
+	go func() {
+		io.WriteString(pipeWriter2, line2)
+		io.WriteString(pipeWriter2, line4)
+		io.WriteString(pipeWriter2, line4)
+		pipeWriter2.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := concatenatedStringsAsBytes(
+		line1,
+		line1,
+		line2,
+		line3,
+		line4,
+		line4,
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Verify that a stream for which the first token is slow to get but within
+// the timeout is multiplexed correctly with a faster stream
+func TestOrderingOneSlowStartReader(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter2, line2)
+		pipeWriter2.Close()
+		time.Sleep(firstTimeout / 2)
+		io.WriteString(pipeWriter1, line1)
+		pipeWriter1.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := concatenatedStringsAsBytes(
+		line1,
+		line2,
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Verify that the aggregated stream does not wait for a stream which is so
+// slow to extract a first token that it exceeds the timeout
+func TestOrderingOneVerySlowStartReader(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter2, line2)
+		pipeWriter2.Close()
+		// if the reader is very slow, ordering
+		// will not be guaranteed as we need to
+		// move on
+		time.Sleep(2 * firstTimeout)
+		io.WriteString(pipeWriter1, line1)
+		pipeWriter1.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := concatenatedStringsAsBytes(
+		line2,
+		line1,
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Verify that a stream for which the tokens are slow to get but within the
+// timeout is multiplexed correctly with a faster stream
+func TestOrderingSlowReaders(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		time.Sleep(timeout / 2)
+		io.WriteString(pipeWriter1, line2)
+		pipeWriter1.Close()
+	}()
+	go func() {
+		io.WriteString(pipeWriter2, line1)
+		io.WriteString(pipeWriter2, line3)
+		pipeWriter2.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := concatenatedStringsAsBytes(
+		line1,
+		line1,
+		line2,
+		line3,
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Verify that the aggregated stream does not wait for a stream which is so
+// slow to extract tokens that it exceeds the timeout
+func TestOrderingVerySlowReaders(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		io.WriteString(pipeWriter2, line1)
+		io.WriteString(pipeWriter2, line3)
+		// if the reader is very slow, ordering
+		// will not be guaranteed as we need to
+		// move on
+		time.Sleep(2 * timeout)
+		io.WriteString(pipeWriter1, line2)
+		pipeWriter1.Close()
+		pipeWriter2.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := concatenatedStringsAsBytes(
+		line1,
+		line1,
+		line3,
+		line2,
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Verify that the overall rate should not be limited by slow readers, once
+// their timeout was exceeded once
+func TestTimeoutsAreBySource(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe() // fast
+		pipeReader2, pipeWriter2 = io.Pipe() // fast initial token, and then hangs
+		pipeReader3, _           = io.Pipe() // hangs from the beginning
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+			Source{Reader: pipeReader3},
+		)
+		written int
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		io.WriteString(pipeWriter1, line2)
+		io.WriteString(pipeWriter1, line3)
+	}()
+	go func() {
+		io.WriteString(pipeWriter2, line1)
+	}()
+	go func() {
+		readOneByteAtTheTime(reader, &written)
+	}()
+	blockingTime := firstTimeout + timeout
+	time.Sleep(blockingTime + timeout/2) // add some margin
+	expected := len(line1 + line1 + line2 + line3)
+	if written != expected {
+		t.Errorf("%v bytes copied, %v expected", written, expected)
+	}
+}
+
+// Verify that a stream producing a token very late does not
+// affect ordering of the well-behaving sources
+func TestVerySlowReaderDoesNotPreemptOthers(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		pipeReader3, pipeWriter3 = io.Pipe()
+		reader                   = NewReader(
+			Options{},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+			Source{Reader: pipeReader3},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		time.Sleep(timeout / 2)
+		io.WriteString(pipeWriter1, line2)
+		pipeWriter1.Close()
+	}()
+	go func() {
+		io.WriteString(pipeWriter2, line3)
+		pipeWriter2.Close()
+	}()
+	go func() {
+		time.Sleep(firstTimeout)
+		io.WriteString(pipeWriter3, line4)
+		pipeWriter3.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := concatenatedStringsAsBytes(
+		line1,
+		line2,
+		line3,
+		line4,
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Check that a custom Split function can be set
+func TestCustomSplit(t *testing.T) {
+	var (
+		pipeReader, pipeWriter = io.Pipe()
+		reader                 = NewReader(
+			Options{Split: bufio.ScanWords},
+			Source{Reader: pipeReader},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter, "1 2 3")
+		pipeWriter.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := []byte("1\n2\n3\n")
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Check that a custom Less function can be set
+func TestCustomLess(t *testing.T) {
+	var (
+		ByDescLenLess            = func(i, j []byte) bool { return len(i) > len(j) }
+		pipeReader1, pipeWriter1 = io.Pipe()
+		pipeReader2, pipeWriter2 = io.Pipe()
+		reader                   = NewReader(
+			Options{Less: ByDescLenLess},
+			Source{Reader: pipeReader1},
+			Source{Reader: pipeReader2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line3)
+		io.WriteString(pipeWriter2, line4)
+		io.WriteString(pipeWriter2, line2)
+		io.WriteString(pipeWriter1, line1)
+		pipeWriter1.Close()
+		pipeWriter2.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	expected := concatenatedStringsAsBytes(
+		line4,
+		line3,
+		line2,
+		line1,
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}
+
+// Check that a custom Write function can be set
+func TestCustomWrites(t *testing.T) {
+	var (
+		pipeReader1, pipeWriter1 = io.Pipe()
+		Write1                   = func(dest io.Writer, token []byte) (n int, err error) {
+			return io.WriteString(dest, "ZZZZ<"+string(token)+">\n")
+		}
+		pipeReader2, pipeWriter2 = io.Pipe()
+		Write2                   = func(dest io.Writer, token []byte) (n int, err error) {
+			return io.WriteString(dest, "AAAA<"+string(token)+">\n")
+		}
+		reader = NewReader(
+			Options{},
+			Source{Reader: pipeReader1, Write: Write1},
+			Source{Reader: pipeReader2, Write: Write2},
+		)
+	)
+	go func() {
+		io.WriteString(pipeWriter1, line1)
+		pipeWriter1.Close()
+		io.WriteString(pipeWriter2, line2)
+		pipeWriter2.Close()
+	}()
+	actual := readOneByteAtTheTime(reader, new(int))
+	// Write2's prefix is "before" Write1's but it must not affect
+	// affect ordering
+	expected := concatenatedStringsAsBytes(
+		"ZZZZ<",
+		strings.Trim(line1, "\n"),
+		">\n",
+		"AAAA<",
+		strings.Trim(line2, "\n"),
+		">\n",
+	)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("`%v` read, `%v` expected", string(actual), string(expected))
+	}
+}


### PR DESCRIPTION
Adds proctype while streaming logs from kubernetes API

Example for default process type `cmd` -
```
[cmd-5fc75d4ccd-459pn]
[cmd-5fc75d4ccd-459pn] > node-js-getting-started@0.2.6 start /app
[cmd-5fc75d4ccd-459pn] > node index.js
[cmd-5fc75d4ccd-459pn]
[cmd-5fc75d4ccd-459pn] Node app is running on port 8000
```
  