### PR TITLE
Reusing load-balancer among apps in a stack

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -31,7 +31,7 @@ func init() {
 func runRpcServer() error {
 	go func() {
 		if err := newServer().Run(); err != nil {
-			log.Fatal(fmt.Errorf("serveGRPC err: %v", err))
+			log.Fatalf("serveGRPC err: %v", err)
 		}
 	}()
 

--- a/api/server.go
+++ b/api/server.go
@@ -90,9 +90,8 @@ type Server struct {
 }
 
 func (s *Server) Run() error {
-	//TODO: should we expose K8sConfigPath for a provider ?
 	if _, err := s.Provider.K8sConfigPath(); err != nil {
-		log.Warn(fmt.Errorf("caching kubernetes config err: %v", err))
+		log.Warnf("attempting to cache kubeconfig: %v. ", err)
 	}
 
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", rpcPort))
@@ -179,7 +178,7 @@ func (s *Server) AppRestart(ctx context.Context, req *pbs.AppRequest) (*empty.Em
 func (s *Server) BuildCreate(ctx context.Context, req *pbs.CreateBuildRequest) (*pb.Build, error) {
 	return s.Provider.BuildCreate(req.App, &pb.CreateBuildOptions{
 		Procfile: req.Procfile,
-		Version: req.Version,
+		Version:  req.Version,
 	})
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ import (
 const (
 	apiHttpPort = 8080
 	apiRpcPort  = 10000
+	apiTimeout  = 10
 )
 
 func init() {
@@ -79,7 +80,7 @@ func GrpcClient(host, password string) (pb.ProviderServiceClient, func() error) 
 	conn, err := grpc.Dial(address,
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
-		grpc.WithTimeout(time.Second*5),
+		grpc.WithTimeout(time.Second*apiTimeout),
 		grpc.WithPerRPCCredentials(&loginCreds{ApiKey: password}),
 	)
 	if err != nil {

--- a/client/process.go
+++ b/client/process.go
@@ -84,7 +84,7 @@ func (c *Client) RunProcess(name string, args []string) error {
 
 	go func(r io.Reader) {
 		defer wg.Done()
-		buf := make([]byte, 1024*1024)
+		buf := make([]byte, 1024)
 
 		for {
 			n, serr := r.Read(buf)

--- a/cloud/kube/deployment.go
+++ b/cloud/kube/deployment.go
@@ -139,18 +139,26 @@ func newIngress(payload *DeployResponse, domains []string) *v1beta1.Ingress {
 		rules[i] = v1beta1.IngressRule{
 			Host: domain,
 			IngressRuleValue: v1beta1.IngressRuleValue{HTTP: &v1beta1.HTTPIngressRuleValue{
-				Paths: []v1beta1.HTTPIngressPath{{Path: "/", Backend: v1beta1.IngressBackend{
-					ServiceName: r.ServiceID,
-					ServicePort: r.ContainerPort,
-				}}},
+				Paths: []v1beta1.HTTPIngressPath{{
+					Path: "/",
+					Backend: v1beta1.IngressBackend{
+						ServiceName: r.ServiceID,
+						ServicePort: r.ContainerPort,
+					},
+				}},
 			}},
 		}
 	}
 
+	//Note: making name dependent on namespace i.e. stackName will only provision one load-balancer per stack
+	// change this if you want to allocate individual load balanacer for each app and use Name = payload.Request.ServiceID
+	// Also if you change this remember to chage in AppGet to fetch IP of load balancer code
+	name := fmt.Sprintf("%s-ing", payload.Request.Namespace)
+
 	return &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   payload.Request.ServiceID,
-			Labels: map[string]string{appLabel: r.App, managedBy: heritage},
+			Name:   name,
+			Labels: map[string]string{managedBy: heritage},
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: rules,

--- a/cloud/kube/helper.go
+++ b/cloud/kube/helper.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"k8s.io/api/extensions/v1beta1"
 )
 
 func toJson(object interface{}) string {
@@ -44,4 +45,26 @@ func MergeAppDomains(domains []string, item string) []string {
 	}
 
 	return domains
+}
+
+func mergeIngressRules(dest *v1beta1.Ingress, source *v1beta1.Ingress) *v1beta1.Ingress {
+	for _, r := range source.Spec.Rules {
+		foundAt := -1
+		for i, rr := range dest.Spec.Rules {
+			if rr.Host == r.Host {
+				foundAt = i
+				break
+			}
+		}
+
+		if foundAt >= 0 {
+			dest.Spec.Rules[foundAt] = r
+		} else {
+			dest.Spec.Rules = append(dest.Spec.Rules, r)
+		}
+	}
+
+	log.Debugf("ingress rules %s", toJson(dest.Spec))
+
+	return dest
 }

--- a/cmd/provider/aws/templates/formation.yaml
+++ b/cmd/provider/aws/templates/formation.yaml
@@ -40,7 +40,7 @@ Metadata:
       Zone0:
         default: Availability Zone
       Zone1:
-        default: Availability Zone
+        default: Second Availability Zone
       AdminIngressLocation:
         default: Admin Ingress Location
       InstanceType:

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -25,8 +25,8 @@ var (
 	credNotFound    = errors.New("Invalid credentials")
 	projectNotFound = errors.New("Invalid project id")
 
-	defaultGcpZone         = "asia-east1-a" //Taiwan
-	defaultAWSZone         = "ap-southeast-1a"
+	defaultGcpZone         = "asia-east1-a"    //Taiwan
+	defaultAWSZone         = "ap-southeast-1a" //Singapur
 	defaultAWSInstanceType = "t2.medium"
 	defaultGCPInstanceType = "n1-standard-1"
 )


### PR DESCRIPTION
To save cost, we should provision one load-balancer per stack on GCP. It doesn't have support for AWS yet.