### PR TITLE
Adding Websocket for bidi-connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELEASED] - 0000-00-00
 ### Added
 - AWS elasticsearch support
+- Websocket connection for streaming logs and Running one-off commands
 
 ## [1.0.0-alpha.11] - 2018-03-02
 ### Added

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -469,7 +469,7 @@
 
 [[projects]]
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace","websocket"]
   revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [[projects]]
@@ -562,6 +562,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b8efe3ea0ce0c7446c61982bf7d36bb8e82ea5dfa42c4f48f22798a560cdf063"
+  inputs-digest = "46839c89b027427ff758080f2a6d231f96ae66876d4d84c45f630b36ef9275f2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/helper.go
+++ b/api/helper.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
+	"golang.org/x/net/websocket"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -80,4 +81,18 @@ func writeToFd(fd io.Writer, data []byte) error {
 			return nil
 		}
 	}
+}
+
+type websocketFunc func(*websocket.Conn) error
+
+func ws(at string, handler websocketFunc) websocket.Handler {
+	return websocket.Handler(func(ws *websocket.Conn) {
+		err := handler(ws)
+
+		if err != nil {
+			log.Error(err)
+			ws.Write([]byte(fmt.Sprintf("ERROR: %v\n", err)))
+			return
+		}
+	})
 }

--- a/api/main.go
+++ b/api/main.go
@@ -28,17 +28,15 @@ func init() {
 	flag.IntVar(&timeout, "timeout", 2, "wait timeout for rpc proxy")
 }
 
-func runRpcServer() error {
+func runRpcServer(server *Server) {
 	go func() {
-		if err := newServer().Run(); err != nil {
+		if err := server.Run(); err != nil {
 			log.Fatalf("serveGRPC err: %v", err)
 		}
 	}()
-
-	return nil
 }
 
-func run() error {
+func runHttpServer(server *Server) error {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -51,7 +49,14 @@ func run() error {
 	}
 
 	mux := http.NewServeMux()
+
+	// Implementing bidi-streaming using GRPC is a lot of headache,
+	// it's better to use websockets protocols for streaming and interactive one-off commands
+	mux.Handle("/ws/v1/logs", ws("appLogs", server.LogStreamWs))
+	mux.Handle("/ws/v1/exec", ws("processExec", server.ProcessRunWs))
+
 	mux.Handle("/", gwmux)
+
 	fmt.Printf("Starting server on http=%d and grpc=%d ports\n", port, rpcPort)
 	return http.ListenAndServe(fmt.Sprintf(":%d", port), mux)
 }
@@ -78,14 +83,12 @@ func setupLogging() {
 
 func main() {
 	setupLogging()
-
-	if err := runRpcServer(); err != nil {
-		log.Fatal(err)
-	}
+	server := newServer()
+	runRpcServer(server)
 
 	time.Sleep(time.Duration(timeout) * time.Second)
 
-	if err := run(); err != nil {
+	if err := runHttpServer(server); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/api/process.go
+++ b/api/process.go
@@ -1,13 +1,27 @@
 package main
 
 import (
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 	pbs "github.com/datacol-io/datacol/api/controller"
 	pb "github.com/datacol-io/datacol/api/models"
 	"github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
+	"golang.org/x/net/websocket"
 	"google.golang.org/grpc/metadata"
 )
+
+func (s *Server) ProcessRunWs(ws *websocket.Conn) error {
+	headers := ws.Request().Header
+	app := headers.Get("app")
+
+	if app == "" {
+		return fmt.Errorf("Missing require param: app")
+	}
+
+	return s.Provider.ProcessRun(app, ws, headers.Get("command"))
+}
 
 func (s *Server) ProcessRun(srv pbs.ProviderService_ProcessRunServer) error {
 	md, _ := metadata.FromIncomingContext(srv.Context())

--- a/api/server.go
+++ b/api/server.go
@@ -71,6 +71,13 @@ func newServer() *Server {
 		}
 
 	case "local":
+		// Local provider uses registry inside minikube VM to store images. Execute following commands to the registry running
+		// inside minikube vm
+		//
+		// minikube start --insecure-registry localhost:5000 && \
+		// 	eval $(minikube docker-env) && \
+		// 	docker run -d -p 5000:5000 --restart=always --name registry registry:2
+
 		provider = &local.LocalCloud{
 			Name:            name,
 			RegistryAddress: "localhost:5000",

--- a/cloud/common/util.go
+++ b/cloud/common/util.go
@@ -94,6 +94,8 @@ func GetJobID(name, process_type string) string {
 
 func GetDefaultProctype(b *pb.Build) string {
 	proctype := CmdProcessKind
+	fmt.Printf("build %+v\n", b)
+
 	if len(b.Procfile) > 0 {
 		proctype = WebProcessKind
 	}

--- a/cloud/kube/common.go
+++ b/cloud/kube/common.go
@@ -207,6 +207,11 @@ func GetServiceEndpoint(c *kubernetes.Clientset, ns, name string) (string, error
 
 func LogStreamReq(c *kubernetes.Clientset, w io.Writer, ns, app string, opts pb.LogStreamOptions) error {
 	pods, err := GetAllPods(c, ns, app)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Got %d pods for app=%s", len(pods), app)
 
 	//TODO: consider using https://github.com/djherbis/stream for reading multiple streams
 	var sources []multiplexio.Source

--- a/cloud/local/build.go
+++ b/cloud/local/build.go
@@ -75,7 +75,7 @@ func (g *LocalCloud) BuildImport(id, filename string) error {
 	repo := fmt.Sprintf("%s/%s", g.RegistryAddress, app)
 	tag := id
 
-	log.Debugf("Tagging image %s to %s", app, repo, tag)
+	log.Debugf("Tagging image %s to %s:%s", app, repo, tag)
 
 	if err := dkr.TagImage(app, docker.TagImageOptions{Repo: repo, Tag: tag}); err != nil {
 		return fmt.Errorf("failed to tag image with %v: %v", tag, err)


### PR DESCRIPTION
Replacing GRPC based bidi-connections with websockets. It's better to
maintain and reason about WebSockets than juggling GRPC payload bytes as
`*websocket.Conn` implements io.Writer/io.Reader.