### PR TITLE
Adding proxy support for infra resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - AWS elasticsearch support
 - Websocket connection for streaming logs and Running one-off commands
 - Added `--ref` flag into deploy cmd
+- Proxy support through bastion Host 
 ### Fixed
 - Embedding Provider for `datacol login`
 - Procfile support for Codecommit based app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED] - 0000-00-00
 ### Added
+- Adding cluster-instance-type and controller-instance-type in `datacol init`
 - AWS elasticsearch support
 - Websocket connection for streaming logs and Running one-off commands
 - Added `--ref` flag into deploy cmd

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ gentest:
 		$(SERVICE_PROTO_DIR)/*.proto
 
 gen:
-	go-bindata -o cmd/provider/aws/templates.go cmd/provider/aws/templates/ && gsed -i 's/main/aws/g' cmd/provider/aws/templates.go
-	go-bindata -o cloud/aws/templates.go cloud/aws/templates/ && gsed -i 's/main/aws/g' cloud/aws/templates.go
-	go-bindata -o cloud/google/templates.go cloud/google/templates/ && gsed -i 's/main/google/g' cloud/google/templates.go
+	go-bindata -o cmd/provider/aws/templates.go cmd/provider/aws/templates/ && sed -i 's/main/aws/g' cmd/provider/aws/templates.go
+	go-bindata -o cloud/aws/templates.go cloud/aws/templates/ && sed -i 's/main/aws/g' cloud/aws/templates.go
+	go-bindata -o cloud/google/templates.go cloud/google/templates/ && sed -i 's/main/google/g' cloud/google/templates.go
 
 	## building api/models/*.proto
 	protoc -I $(MODEL_PROTO_DIR) $(PROTOC_INCLUDE_DIR) \

--- a/api/helper.go
+++ b/api/helper.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"os"
 	"strings"
+	"sync"
 
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -68,6 +71,36 @@ func checkHttpAuthorization(value, expected string) bool {
 	return pair[1] == expected
 }
 
+func checkAPIKey(r *http.Request) bool {
+	if os.Getenv("DATACOL_API_KEY") == "" {
+		return true
+	}
+
+	auth := r.Header.Get("Authorization")
+
+	if auth == "" {
+		return false
+	}
+
+	if !strings.HasPrefix(auth, "Basic ") {
+		return false
+	}
+
+	c, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+
+	if err != nil {
+		return false
+	}
+
+	parts := strings.SplitN(string(c), ":", 2)
+
+	if len(parts) != 2 || parts[1] != os.Getenv("DATACOL_API_KEY") {
+		return false
+	}
+
+	return true
+}
+
 func writeToFd(fd io.Writer, data []byte) error {
 	w := 0
 	n := len(data)
@@ -87,6 +120,11 @@ type websocketFunc func(*websocket.Conn) error
 
 func ws(at string, handler websocketFunc) websocket.Handler {
 	return websocket.Handler(func(ws *websocket.Conn) {
+		if !checkAPIKey(ws.Request()) {
+			ws.Write([]byte("Unable to authenticate. Invalid ApiKey."))
+			return
+		}
+
 		err := handler(ws)
 
 		if err != nil {
@@ -95,4 +133,9 @@ func ws(at string, handler websocketFunc) websocket.Handler {
 			return
 		}
 	})
+}
+
+func copyAsync(dst io.Writer, src io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+	io.Copy(dst, src)
 }

--- a/api/main.go
+++ b/api/main.go
@@ -54,7 +54,7 @@ func runHttpServer(server *Server) error {
 	// it's better to use websockets protocols for streaming and interactive one-off commands
 	mux.Handle("/ws/v1/logs", ws("appLogs", server.LogStreamWs))
 	mux.Handle("/ws/v1/exec", ws("processExec", server.ProcessRunWs))
-
+	mux.Handle("/ws/v1/proxy", ws("appProxy", server.ResourceProxy))
 	mux.Handle("/", gwmux)
 
 	fmt.Printf("Starting server on http=%d and grpc=%d ports\n", port, rpcPort)

--- a/api/models/types.pb.go
+++ b/api/models/types.pb.go
@@ -877,24 +877,6 @@ func (m *Formation) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func encodeFixed64Types(dAtA []byte, offset int, v uint64) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	dAtA[offset+4] = uint8(v >> 32)
-	dAtA[offset+5] = uint8(v >> 40)
-	dAtA[offset+6] = uint8(v >> 48)
-	dAtA[offset+7] = uint8(v >> 56)
-	return offset + 8
-}
-func encodeFixed32Types(dAtA []byte, offset int, v uint32) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	return offset + 4
-}
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
@@ -2056,51 +2038,14 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var keykey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				keykey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			var stringLenmapkey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLenmapkey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLenmapkey := int(stringLenmapkey)
-			if intStringLenmapkey < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postStringIndexmapkey := iNdEx + intStringLenmapkey
-			if postStringIndexmapkey > l {
-				return io.ErrUnexpectedEOF
-			}
-			mapkey := string(dAtA[iNdEx:postStringIndexmapkey])
-			iNdEx = postStringIndexmapkey
 			if m.Exports == nil {
 				m.Exports = make(map[string]string)
 			}
-			if iNdEx < postIndex {
-				var valuekey uint64
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return ErrIntOverflowTypes
@@ -2110,41 +2055,80 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					valuekey |= (uint64(b) & 0x7F) << shift
+					wire |= (uint64(b) & 0x7F) << shift
 					if b < 0x80 {
 						break
 					}
 				}
-				var stringLenmapvalue uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
-					if iNdEx >= l {
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					stringLenmapvalue |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipTypes(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
 				}
-				intStringLenmapvalue := int(stringLenmapvalue)
-				if intStringLenmapvalue < 0 {
-					return ErrInvalidLengthTypes
-				}
-				postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-				if postStringIndexmapvalue > l {
-					return io.ErrUnexpectedEOF
-				}
-				mapvalue := string(dAtA[iNdEx:postStringIndexmapvalue])
-				iNdEx = postStringIndexmapvalue
-				m.Exports[mapkey] = mapvalue
-			} else {
-				var mapvalue string
-				m.Exports[mapkey] = mapvalue
 			}
+			m.Exports[mapkey] = mapvalue
 			iNdEx = postIndex
 		case 9:
 			if wireType != 2 {
@@ -2172,51 +2156,14 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var keykey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				keykey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			var stringLenmapkey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLenmapkey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLenmapkey := int(stringLenmapkey)
-			if intStringLenmapkey < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postStringIndexmapkey := iNdEx + intStringLenmapkey
-			if postStringIndexmapkey > l {
-				return io.ErrUnexpectedEOF
-			}
-			mapkey := string(dAtA[iNdEx:postStringIndexmapkey])
-			iNdEx = postStringIndexmapkey
 			if m.Parameters == nil {
 				m.Parameters = make(map[string]string)
 			}
-			if iNdEx < postIndex {
-				var valuekey uint64
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return ErrIntOverflowTypes
@@ -2226,41 +2173,80 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					valuekey |= (uint64(b) & 0x7F) << shift
+					wire |= (uint64(b) & 0x7F) << shift
 					if b < 0x80 {
 						break
 					}
 				}
-				var stringLenmapvalue uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
-					if iNdEx >= l {
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					stringLenmapvalue |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipTypes(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
 				}
-				intStringLenmapvalue := int(stringLenmapvalue)
-				if intStringLenmapvalue < 0 {
-					return ErrInvalidLengthTypes
-				}
-				postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-				if postStringIndexmapvalue > l {
-					return io.ErrUnexpectedEOF
-				}
-				mapvalue := string(dAtA[iNdEx:postStringIndexmapvalue])
-				iNdEx = postStringIndexmapvalue
-				m.Parameters[mapkey] = mapvalue
-			} else {
-				var mapvalue string
-				m.Parameters[mapkey] = mapvalue
 			}
+			m.Parameters[mapkey] = mapvalue
 			iNdEx = postIndex
 		case 10:
 			if wireType != 2 {
@@ -2288,51 +2274,14 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var keykey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				keykey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			var stringLenmapkey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLenmapkey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLenmapkey := int(stringLenmapkey)
-			if intStringLenmapkey < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postStringIndexmapkey := iNdEx + intStringLenmapkey
-			if postStringIndexmapkey > l {
-				return io.ErrUnexpectedEOF
-			}
-			mapkey := string(dAtA[iNdEx:postStringIndexmapkey])
-			iNdEx = postStringIndexmapkey
 			if m.Outputs == nil {
 				m.Outputs = make(map[string]string)
 			}
-			if iNdEx < postIndex {
-				var valuekey uint64
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return ErrIntOverflowTypes
@@ -2342,41 +2291,80 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					valuekey |= (uint64(b) & 0x7F) << shift
+					wire |= (uint64(b) & 0x7F) << shift
 					if b < 0x80 {
 						break
 					}
 				}
-				var stringLenmapvalue uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
-					if iNdEx >= l {
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					stringLenmapvalue |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipTypes(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
 				}
-				intStringLenmapvalue := int(stringLenmapvalue)
-				if intStringLenmapvalue < 0 {
-					return ErrInvalidLengthTypes
-				}
-				postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-				if postStringIndexmapvalue > l {
-					return io.ErrUnexpectedEOF
-				}
-				mapvalue := string(dAtA[iNdEx:postStringIndexmapvalue])
-				iNdEx = postStringIndexmapvalue
-				m.Outputs[mapkey] = mapvalue
-			} else {
-				var mapvalue string
-				m.Outputs[mapkey] = mapvalue
 			}
+			m.Outputs[mapkey] = mapvalue
 			iNdEx = postIndex
 		case 11:
 			if wireType != 2 {
@@ -2404,51 +2392,14 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var keykey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				keykey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			var stringLenmapkey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLenmapkey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLenmapkey := int(stringLenmapkey)
-			if intStringLenmapkey < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postStringIndexmapkey := iNdEx + intStringLenmapkey
-			if postStringIndexmapkey > l {
-				return io.ErrUnexpectedEOF
-			}
-			mapkey := string(dAtA[iNdEx:postStringIndexmapkey])
-			iNdEx = postStringIndexmapkey
 			if m.Tags == nil {
 				m.Tags = make(map[string]string)
 			}
-			if iNdEx < postIndex {
-				var valuekey uint64
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return ErrIntOverflowTypes
@@ -2458,41 +2409,80 @@ func (m *Resource) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					valuekey |= (uint64(b) & 0x7F) << shift
+					wire |= (uint64(b) & 0x7F) << shift
 					if b < 0x80 {
 						break
 					}
 				}
-				var stringLenmapvalue uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
-					if iNdEx >= l {
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					stringLenmapvalue |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipTypes(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
 				}
-				intStringLenmapvalue := int(stringLenmapvalue)
-				if intStringLenmapvalue < 0 {
-					return ErrInvalidLengthTypes
-				}
-				postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-				if postStringIndexmapvalue > l {
-					return io.ErrUnexpectedEOF
-				}
-				mapvalue := string(dAtA[iNdEx:postStringIndexmapvalue])
-				iNdEx = postStringIndexmapvalue
-				m.Tags[mapkey] = mapvalue
-			} else {
-				var mapvalue string
-				m.Tags[mapkey] = mapvalue
 			}
+			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2678,51 +2668,14 @@ func (m *EnvConfig) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var keykey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				keykey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			var stringLenmapkey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLenmapkey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLenmapkey := int(stringLenmapkey)
-			if intStringLenmapkey < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postStringIndexmapkey := iNdEx + intStringLenmapkey
-			if postStringIndexmapkey > l {
-				return io.ErrUnexpectedEOF
-			}
-			mapkey := string(dAtA[iNdEx:postStringIndexmapkey])
-			iNdEx = postStringIndexmapkey
 			if m.Data == nil {
 				m.Data = make(map[string]string)
 			}
-			if iNdEx < postIndex {
-				var valuekey uint64
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return ErrIntOverflowTypes
@@ -2732,41 +2685,80 @@ func (m *EnvConfig) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					valuekey |= (uint64(b) & 0x7F) << shift
+					wire |= (uint64(b) & 0x7F) << shift
 					if b < 0x80 {
 						break
 					}
 				}
-				var stringLenmapvalue uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
-					if iNdEx >= l {
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					stringLenmapvalue |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipTypes(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
 				}
-				intStringLenmapvalue := int(stringLenmapvalue)
-				if intStringLenmapvalue < 0 {
-					return ErrInvalidLengthTypes
-				}
-				postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-				if postStringIndexmapvalue > l {
-					return io.ErrUnexpectedEOF
-				}
-				mapvalue := string(dAtA[iNdEx:postStringIndexmapvalue])
-				iNdEx = postStringIndexmapvalue
-				m.Data[mapkey] = mapvalue
-			} else {
-				var mapvalue string
-				m.Data[mapkey] = mapvalue
 			}
+			m.Data[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3029,51 +3021,14 @@ func (m *Formation) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var keykey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				keykey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			var stringLenmapkey uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLenmapkey |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLenmapkey := int(stringLenmapkey)
-			if intStringLenmapkey < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postStringIndexmapkey := iNdEx + intStringLenmapkey
-			if postStringIndexmapkey > l {
-				return io.ErrUnexpectedEOF
-			}
-			mapkey := string(dAtA[iNdEx:postStringIndexmapkey])
-			iNdEx = postStringIndexmapkey
 			if m.Structure == nil {
 				m.Structure = make(map[string]int32)
 			}
-			if iNdEx < postIndex {
-				var valuekey uint64
+			var mapkey string
+			var mapvalue int32
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return ErrIntOverflowTypes
@@ -3083,31 +3038,69 @@ func (m *Formation) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					valuekey |= (uint64(b) & 0x7F) << shift
+					wire |= (uint64(b) & 0x7F) << shift
 					if b < 0x80 {
 						break
 					}
 				}
-				var mapvalue int32
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowTypes
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
-					if iNdEx >= l {
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					mapvalue |= (int32(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapvalue |= (int32(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
 					}
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipTypes(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
 				}
-				m.Structure[mapkey] = mapvalue
-			} else {
-				var mapvalue int32
-				m.Structure[mapkey] = mapvalue
 			}
+			m.Structure[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/process.go
+++ b/api/process.go
@@ -18,15 +18,15 @@ import (
 
 func (s *Server) ResourceProxy(ws *websocket.Conn) error {
 	headers := ws.Request().Header
-	host := headers.Get("host")
-	port := headers.Get("port")
+	host := headers.Get("remotehost")
+	port := headers.Get("remoteport")
 
 	if host == "" {
-		return errors.New("Missing required header: host")
+		return errors.New("Missing required header: remotehost")
 	}
 
 	if port == "" {
-		return errors.New("Missing required header: port")
+		return errors.New("Missing required header: remoteport")
 	}
 
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%s", host, port), 3*time.Second)

--- a/client/apps.go
+++ b/client/apps.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -62,4 +63,11 @@ func (c *Client) GetEnvironment(name string) (pb.Environment, error) {
 func (c *Client) SetEnvironment(name string, data string) error {
 	_, err := c.ProviderServiceClient.EnvironmentSet(ctx, &pbs.EnvSetRequest{Name: name, Data: data})
 	return err
+}
+
+func (c *Client) ProxyRemote(host string, port int, conn io.ReadWriteCloser) error {
+	return c.Stream("/ws/proxy", map[string]string{
+		"host": host,
+		"port": fmt.Sprintf("%d", port),
+	}, conn, conn)
 }

--- a/client/apps.go
+++ b/client/apps.go
@@ -66,8 +66,8 @@ func (c *Client) SetEnvironment(name string, data string) error {
 }
 
 func (c *Client) ProxyRemote(host string, port int, conn io.ReadWriteCloser) error {
-	return c.Stream("/ws/proxy", map[string]string{
-		"host": host,
-		"port": fmt.Sprintf("%d", port),
+	return c.Stream("/ws/v1/proxy", map[string]string{
+		"remotehost": host,
+		"remoteport": fmt.Sprintf("%d", port),
 	}, conn, conn)
 }

--- a/cloud/aws/templates.go
+++ b/cloud/aws/templates.go
@@ -87,7 +87,7 @@ func cloudAwsTemplatesAppTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cloud/aws/templates/app.tmpl", size: 6660, mode: os.FileMode(420), modTime: time.Unix(1519994908, 0)}
+	info := bindataFileInfo{name: "cloud/aws/templates/app.tmpl", size: 6660, mode: os.FileMode(436), modTime: time.Unix(1520015640, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -107,7 +107,7 @@ func cloudAwsTemplatesElasticsearchTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cloud/aws/templates/elasticsearch.tmpl", size: 4023, mode: os.FileMode(420), modTime: time.Unix(1520701517, 0)}
+	info := bindataFileInfo{name: "cloud/aws/templates/elasticsearch.tmpl", size: 4023, mode: os.FileMode(436), modTime: time.Unix(1520679773, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -127,7 +127,7 @@ func cloudAwsTemplatesMysqlTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cloud/aws/templates/mysql.tmpl", size: 3587, mode: os.FileMode(420), modTime: time.Unix(1500616848, 0)}
+	info := bindataFileInfo{name: "cloud/aws/templates/mysql.tmpl", size: 3587, mode: os.FileMode(436), modTime: time.Unix(1520015640, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -147,7 +147,7 @@ func cloudAwsTemplatesPostgresTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cloud/aws/templates/postgres.tmpl", size: 4389, mode: os.FileMode(420), modTime: time.Unix(1520701517, 0)}
+	info := bindataFileInfo{name: "cloud/aws/templates/postgres.tmpl", size: 4389, mode: os.FileMode(436), modTime: time.Unix(1520679773, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -167,7 +167,7 @@ func cloudAwsTemplatesRedisTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cloud/aws/templates/redis.tmpl", size: 3164, mode: os.FileMode(420), modTime: time.Unix(1500616848, 0)}
+	info := bindataFileInfo{name: "cloud/aws/templates/redis.tmpl", size: 3164, mode: os.FileMode(436), modTime: time.Unix(1520271844, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cloud/google/templates.go
+++ b/cloud/google/templates.go
@@ -84,7 +84,7 @@ func cloudGoogleTemplatesMysqlTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cloud/google/templates/mysql.tmpl", size: 1392, mode: os.FileMode(420), modTime: time.Unix(1506691380, 0)}
+	info := bindataFileInfo{name: "cloud/google/templates/mysql.tmpl", size: 1392, mode: os.FileMode(436), modTime: time.Unix(1520015640, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func cloudGoogleTemplatesPostgresTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cloud/google/templates/postgres.tmpl", size: 1134, mode: os.FileMode(420), modTime: time.Unix(1502614896, 0)}
+	info := bindataFileInfo{name: "cloud/google/templates/postgres.tmpl", size: 1134, mode: os.FileMode(436), modTime: time.Unix(1520015640, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/provider/aws/amazon.go
+++ b/cmd/provider/aws/amazon.go
@@ -35,9 +35,11 @@ var (
 )
 
 type InitOptions struct {
-	Name, Region, Zone, Bucket         string
-	APIKey, Version, ArtifactBucket    string
-	InstanceType, KeyName              string
+	Name, Region, Zone, Bucket      string
+	APIKey, Version, ArtifactBucket string
+	ClusterInstanceType, KeyName    string
+	ControllerInstanceType          string
+
 	DiskSize, NumNodes, ControllerPort int
 	UseSpotInstance, CreateCluster     bool
 }
@@ -76,6 +78,10 @@ func InitializeStack(opts *InitOptions, creds *AwsCredentials) (*initResponse, e
 		mkCluster = "false"
 	}
 
+	if opts.ControllerInstanceType == "" {
+		opts.ControllerInstanceType = bastionType
+	}
+
 	req := &cloudformation.CreateStackInput{
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},
 		Parameters: []*cloudformation.Parameter{
@@ -85,11 +91,11 @@ func InitializeStack(opts *InitOptions, creds *AwsCredentials) (*initResponse, e
 			{ParameterKey: aws.String("KeyMaterial"), ParameterValue: resp.KeyMaterial},
 			{ParameterKey: aws.String("ApiKey"), ParameterValue: aws.String(opts.APIKey)},
 			{ParameterKey: aws.String("DiskSizeGb"), ParameterValue: aws.String(fmt.Sprintf("%d", opts.DiskSize))},
-			{ParameterKey: aws.String("BastionInstanceType"), ParameterValue: aws.String(bastionType)},
+			{ParameterKey: aws.String("BastionInstanceType"), ParameterValue: aws.String(opts.ControllerInstanceType)},
 			{ParameterKey: aws.String("AdminIngressLocation"), ParameterValue: aws.String(adminIngressLoc)},
 			{ParameterKey: aws.String("NetworkingProvider"), ParameterValue: aws.String(networkProvider)},
 			{ParameterKey: aws.String("K8sNodeCapacity"), ParameterValue: aws.String(fmt.Sprintf("%d", opts.NumNodes-1))},
-			{ParameterKey: aws.String("InstanceType"), ParameterValue: aws.String(opts.InstanceType)},
+			{ParameterKey: aws.String("InstanceType"), ParameterValue: aws.String(opts.ClusterInstanceType)},
 			{ParameterKey: aws.String("DatacolVersion"), ParameterValue: aws.String(opts.Version)},
 			{ParameterKey: aws.String("ArtifactBucket"), ParameterValue: aws.String(opts.ArtifactBucket)},
 			{ParameterKey: aws.String("SettingBucket"), ParameterValue: aws.String(opts.Bucket)},

--- a/cmd/provider/aws/templates.go
+++ b/cmd/provider/aws/templates.go
@@ -83,7 +83,7 @@ func cmdProviderAwsTemplatesFormationYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cmd/provider/aws/templates/formation.yaml", size: 22170, mode: os.FileMode(420), modTime: time.Unix(1520794233, 0)}
+	info := bindataFileInfo{name: "cmd/provider/aws/templates/formation.yaml", size: 22170, mode: os.FileMode(436), modTime: time.Unix(1521183917, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/provider/gcp/gcp.go
+++ b/cmd/provider/gcp/gcp.go
@@ -38,6 +38,9 @@ type InitOptions struct {
 	// SA stands for Service Account
 	SAKeyPath, SAEmail, ClusterVersion string
 
+	// Default machine type for controller/api
+	ControllerMachineType string
+
 	DiskSize, NumNodes, ControllerPort int
 	ClusterNotExists, Preemptible      bool
 }

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -23,7 +23,7 @@ func init() {
 
 func cmdStackProxy(c *cli.Context) error {
 	for _, arg := range c.Args() {
-		parts := strings.SplitN(arg, ":", 2)
+		parts := strings.SplitN(arg, ":", 3)
 
 		var (
 			host           string
@@ -36,8 +36,8 @@ func cmdStackProxy(c *cli.Context) error {
 			port = parseInt(parts[1])
 			hostport = port
 		case 3:
-			host = parts[0]
-			port = parseInt(parts[1])
+			port = parseInt(parts[0])
+			host = parts[1]
 			hostport = parseInt(parts[2])
 		default:
 			stdcli.ExitOnError(fmt.Errorf("invalid argument: %s", arg))

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/datacol-io/datacol/client"
+	"github.com/datacol-io/datacol/cmd/stdcli"
+	"github.com/urfave/cli"
+)
+
+func init() {
+	stdcli.AddCommand(cli.Command{
+		Name:        "proxy",
+		Description: "proxy local ports into a stack",
+		Action:      cmdStackProxy,
+		Flags:       []cli.Flag{stackFlag},
+	})
+}
+
+func cmdStackProxy(c *cli.Context) error {
+	for _, arg := range c.Args() {
+		parts := strings.SplitN(arg, ":", 2)
+
+		host := "localhost" // hardcoding it since we only have 1 bastion host
+
+		var port, hostport int
+		switch len(parts) {
+		case 1:
+			port = parseInt(parts[0])
+			hostport = port
+		case 2:
+			port = parseInt(parts[0])
+			hostport = parseInt(parts[1])
+		default:
+			stdcli.ExitOnError(fmt.Errorf("invalid argument: %s", arg))
+		}
+
+		client, close := getApiClient(c)
+		defer close()
+
+		go proxy("127.0.0.1", port, host, hostport, client)
+	}
+
+	select {}
+}
+
+func parseInt(str string) int {
+	p, err := strconv.Atoi(str)
+	if err != nil {
+		stdcli.ExitOnError(err)
+	}
+	return p
+}
+
+func proxy(localhost string, localport int, remotehost string, remoteport int, client *client.Client) {
+	fmt.Printf("proxying %s:%d to %s:%d\n", localhost, localport, remotehost, remoteport)
+
+	listener, err := net.Listen("tcp4", fmt.Sprintf("%s:%d", localhost, localport))
+	if err != nil {
+		fmt.Printf("error: %s\n", err)
+		return
+	}
+
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Printf("error: %s\n", err)
+			return
+		}
+
+		defer conn.Close()
+
+		fmt.Printf("connect: %d\n", localport)
+
+		go func() {
+			err := client.ProxyRemote(remotehost, remoteport, conn)
+			if err != nil {
+				fmt.Printf("error: %s\n", err)
+				conn.Close()
+				return
+			}
+		}()
+	}
+}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -16,6 +16,7 @@ func init() {
 		Name:        "proxy",
 		Description: "proxy local ports into a stack",
 		Action:      cmdStackProxy,
+		ArgsUsage:   "<[port:]host:hostport>",
 		Flags:       []cli.Flag{stackFlag},
 	})
 }
@@ -24,16 +25,20 @@ func cmdStackProxy(c *cli.Context) error {
 	for _, arg := range c.Args() {
 		parts := strings.SplitN(arg, ":", 2)
 
-		host := "localhost" // hardcoding it since we only have 1 bastion host
+		var (
+			host           string
+			port, hostport int
+		)
 
-		var port, hostport int
 		switch len(parts) {
-		case 1:
-			port = parseInt(parts[0])
-			hostport = port
 		case 2:
-			port = parseInt(parts[0])
-			hostport = parseInt(parts[1])
+			host = parts[0]
+			port = parseInt(parts[1])
+			hostport = port
+		case 3:
+			host = parts[0]
+			port = parseInt(parts[1])
+			hostport = parseInt(parts[2])
 		default:
 			stdcli.ExitOnError(fmt.Errorf("invalid argument: %s", arg))
 		}


### PR DESCRIPTION
Adding a new command `proxy` to create a tunnel through bastion host to your localhost to easy access the resources running into a private network. They might be running into GCP private subnetwork or AWS VPC.

`datacol proxy -h`